### PR TITLE
feat(core): enables user to specify the renderTarget (and toDataTexture) options

### DIFF
--- a/src/core/QuadRenderer.ts
+++ b/src/core/QuadRenderer.ts
@@ -1,19 +1,19 @@
 import {
   ByteType,
+  ClampToEdgeWrapping,
   ColorSpace,
   DataTexture,
   FloatType,
   HalfFloatType,
   IntType,
   LinearFilter,
-  LinearMipMapLinearFilter,
   LinearSRGBColorSpace,
   Material,
   Mesh,
   MeshBasicMaterial,
   OrthographicCamera,
   PlaneGeometry,
-  RepeatWrapping,
+  RenderTargetOptions,
   RGBAFormat,
   Scene,
   ShaderMaterial,
@@ -26,6 +26,8 @@ import {
   WebGLRenderer,
   WebGLRenderTarget
 } from 'three'
+
+import { QuadRendererTextureOptions } from './types'
 /**
  * Utility Type that translates `three` texture types to their TypedArray counterparts.
  *
@@ -41,6 +43,37 @@ export type TextureDataTypeToBufferType<TType extends TextureDataType> =
   TType extends typeof IntType ? Int32Array :
   TType extends typeof FloatType ? Float32Array :
   never
+
+export type QuadRendererOptions<TType extends TextureDataType, TMaterial extends Material> = {
+  /**
+   * Width of the render target
+   */
+  width: number
+  /**
+   * height of the renderTarget
+   */
+  height: number
+  /**
+   * TextureDataType of the renderTarget
+   */
+  type: TType
+  /**
+   * ColorSpace of the renderTarget
+   */
+  colorSpace: ColorSpace
+  /**
+   * material to use for rendering
+   */
+  material: TMaterial
+  /**
+   * Renderer instance to use
+   */
+  renderer?: WebGLRenderer
+  /**
+   * Additional renderTarget options
+   */
+  renderTargetOptions?: QuadRendererTextureOptions
+}
 
 const getBufferForType = (type: TextureDataType, width: number, height: number) => {
   let out: ArrayLike<number>
@@ -82,23 +115,13 @@ let _canReadPixelsResult: boolean | undefined
  * @param type
  * @param renderer
  * @param camera
+ * @param renderTargetOptions
  * @returns
  */
-const canReadPixels = (type: TextureDataType, renderer: WebGLRenderer, camera: OrthographicCamera) => {
+const canReadPixels = (type: TextureDataType, renderer: WebGLRenderer, camera: OrthographicCamera, renderTargetOptions: RenderTargetOptions) => {
   if (_canReadPixelsResult !== undefined) return _canReadPixelsResult
 
-  const testRT = new WebGLRenderTarget(1, 1, {
-    type,
-    colorSpace: LinearSRGBColorSpace,
-    format: RGBAFormat,
-    magFilter: LinearFilter,
-    minFilter: LinearFilter,
-    wrapS: RepeatWrapping,
-    wrapT: RepeatWrapping,
-    depthBuffer: false,
-    stencilBuffer: false,
-    generateMipmaps: true
-  })
+  const testRT = new WebGLRenderTarget(1, 1, renderTargetOptions)
 
   renderer.setRenderTarget(testRT)
   const mesh = new Mesh(new PlaneGeometry(), new MeshBasicMaterial({ color: 0xffffff }))
@@ -138,15 +161,32 @@ export class QuadRenderer<TType extends TextureDataType, TMaterial extends Mater
    * @param sourceTexture
    * @param renderer
    */
-  constructor (width: number, height: number, type: TType, colorSpace: ColorSpace, material: TMaterial, renderer?:WebGLRenderer) {
-    this._width = width
-    this._height = height
-    this._type = type
-    this._colorSpace = colorSpace
+  constructor (options: QuadRendererOptions<TType, TMaterial>) {
+    this._width = options.width
+    this._height = options.height
+    this._type = options.type
+    this._colorSpace = options.colorSpace
 
-    this._material = material
-    if (renderer) {
-      this._renderer = renderer
+    const rtOptions: RenderTargetOptions = {
+      // fixed options
+      format: RGBAFormat,
+      depthBuffer: false,
+      stencilBuffer: false,
+      // user options
+      type: this._type, // set in class property
+      colorSpace: this._colorSpace, // set in class property
+      anisotropy: options.renderTargetOptions?.anisotropy !== undefined ? options.renderTargetOptions?.anisotropy : 1,
+      generateMipmaps: options.renderTargetOptions?.generateMipmaps !== undefined ? options.renderTargetOptions?.generateMipmaps : false,
+      magFilter: options.renderTargetOptions?.magFilter !== undefined ? options.renderTargetOptions?.magFilter : LinearFilter,
+      minFilter: options.renderTargetOptions?.minFilter !== undefined ? options.renderTargetOptions?.minFilter : LinearFilter,
+      samples: options.renderTargetOptions?.samples !== undefined ? options.renderTargetOptions?.samples : undefined,
+      wrapS: options.renderTargetOptions?.wrapS !== undefined ? options.renderTargetOptions?.wrapS : ClampToEdgeWrapping,
+      wrapT: options.renderTargetOptions?.wrapT !== undefined ? options.renderTargetOptions?.wrapT : ClampToEdgeWrapping
+    }
+
+    this._material = options.material
+    if (options.renderer) {
+      this._renderer = options.renderer
     } else {
       this._renderer = QuadRenderer.instantiateRenderer()
       this._rendererIsDisposable = true
@@ -161,7 +201,7 @@ export class QuadRenderer<TType extends TextureDataType, TMaterial extends Mater
     this._camera.bottom = -0.5
     this._camera.updateProjectionMatrix()
 
-    if (!canReadPixels(this._type, this._renderer, this._camera)) {
+    if (!canReadPixels(this._type, this._renderer, this._camera, rtOptions)) {
       let alternativeType: TextureDataType | undefined
       switch (this._type) {
         case HalfFloatType:
@@ -182,18 +222,8 @@ export class QuadRenderer<TType extends TextureDataType, TMaterial extends Mater
     this._quad.geometry.computeBoundingBox()
     this._scene.add(this._quad)
 
-    this._renderTarget = new WebGLRenderTarget(width, height, {
-      type: this._type,
-      colorSpace,
-      format: RGBAFormat,
-      magFilter: LinearFilter,
-      minFilter: LinearMipMapLinearFilter,
-      wrapS: RepeatWrapping,
-      wrapT: RepeatWrapping,
-      depthBuffer: false,
-      stencilBuffer: false,
-      generateMipmaps: true
-    })
+    this._renderTarget = new WebGLRenderTarget(this.width, this.height, rtOptions)
+    this._renderTarget.texture.mapping = options.renderTargetOptions?.mapping !== undefined ? options.renderTargetOptions?.mapping : UVMapping
   }
 
   /**
@@ -242,23 +272,31 @@ export class QuadRenderer<TType extends TextureDataType, TMaterial extends Mater
    * Performs a readPixel operation in the renderTarget
    * and returns a DataTexture containing the read data
    *
+   * @params options
    * @returns
    */
-  public toDataTexture () {
-    return new DataTexture(
+  public toDataTexture (options?: QuadRendererTextureOptions) {
+    const returnValue = new DataTexture(
+      // fixed values
       this.toArray(),
       this.width,
       this.height,
       RGBAFormat,
       this._type,
-      UVMapping,
-      RepeatWrapping,
-      RepeatWrapping,
-      LinearFilter,
-      LinearMipMapLinearFilter,
-      1,
+      // user values
+      options?.mapping || UVMapping,
+      options?.wrapS || ClampToEdgeWrapping,
+      options?.wrapT || ClampToEdgeWrapping,
+      options?.magFilter || LinearFilter,
+      options?.minFilter || LinearFilter,
+      options?.anisotropy || 1,
+      // fixed value
       LinearSRGBColorSpace
     )
+    // set this afterwards, we can't set it in constructor
+    returnValue.generateMipmaps = options?.generateMipmaps !== undefined ? options?.generateMipmaps : false
+
+    return returnValue
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,5 @@
+import { Mapping, RenderTargetOptions } from 'three'
+
 /**
  * This is the Metadata stored in an encoded Gainmap which is used
  * to decode it and return an HDR image
@@ -61,4 +63,18 @@ export type GainMapMetadata = {
    * (divided by) that of the SDR image, at a given pixel.
    */
   gainMapMax: [number, number, number]
+}
+
+/**
+ *
+ */
+export type QuadRendererTextureOptions = Omit<RenderTargetOptions, 'type' | 'format'| 'colorSpace' | 'encoding' | 'depthTexture' | 'stencilBuffer' | 'depthBuffer' | 'internalFormat'> & {
+  /**
+   * @defaultValue {@link UVMapping}
+   */
+  mapping?: Mapping,
+  /**
+   * @defaultValue 1
+   */
+  anisotropy?: number
 }

--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -83,9 +83,19 @@ export const decode = (params: DecodeParameters): InstanceType<typeof QuadRender
     sdr,
     gainMap
   })
-  // TODO: three types are generic, eslint complains here, see how we can solve
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-  const quadRenderer = new QuadRenderer(sdr.image.width, sdr.image.height, HalfFloatType, LinearSRGBColorSpace, material, renderer)
+  const quadRenderer = new QuadRenderer({
+    // TODO: three types are generic, eslint complains here, see how we can solve
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    width: sdr.image.width,
+    // TODO: three types are generic, eslint complains here, see how we can solve
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    height: sdr.image.height,
+    type: HalfFloatType,
+    colorSpace: LinearSRGBColorSpace,
+    material,
+    renderer,
+    renderTargetOptions: params.renderTargetOptions
+  })
   try {
     quadRenderer.render()
   } catch (e) {

--- a/src/decode/loaders/LoaderBase.ts
+++ b/src/decode/loaders/LoaderBase.ts
@@ -15,12 +15,13 @@ import {
 } from 'three'
 
 import { QuadRenderer } from '../../core/QuadRenderer'
-import { type GainMapMetadata } from '../../core/types'
+import { type GainMapMetadata, QuadRendererTextureOptions } from '../../core/types'
 import { GainMapDecoderMaterial } from '../materials/GainMapDecoderMaterial'
 import { getHTMLImageFromBlob } from '../utils/get-html-image-from-blob'
 
 export class LoaderBase<TUrl = string> extends Loader<QuadRenderer<typeof HalfFloatType, GainMapDecoderMaterial>, TUrl> {
   private _renderer: WebGLRenderer
+  private _renderTargetOptions?: QuadRendererTextureOptions
   /**
    * @private
    */
@@ -34,6 +35,17 @@ export class LoaderBase<TUrl = string> extends Loader<QuadRenderer<typeof HalfFl
     super(manager)
     this._renderer = renderer
     this._internalLoadingManager = new LoadingManager()
+  }
+
+  /**
+   * Specify the renderTarget options to use when rendering the gain map
+   *
+   * @param options
+   * @returns
+   */
+  public setRenderTargetOptions (options: QuadRendererTextureOptions) {
+    this._renderTargetOptions = options
+    return this
   }
 
   /**
@@ -55,14 +67,15 @@ export class LoaderBase<TUrl = string> extends Loader<QuadRenderer<typeof HalfFl
       sdr: new Texture()
     })
 
-    return new QuadRenderer(
-      16,
-      16,
-      HalfFloatType,
-      LinearSRGBColorSpace,
+    return new QuadRenderer({
+      width: 16,
+      height: 16,
+      type: HalfFloatType,
+      colorSpace: LinearSRGBColorSpace,
       material,
-      this._renderer
-    )
+      renderer: this._renderer,
+      renderTargetOptions: this._renderTargetOptions
+    })
   }
 
   /**

--- a/src/decode/types.ts
+++ b/src/decode/types.ts
@@ -1,6 +1,6 @@
 import { type Texture, type WebGLRenderer } from 'three'
 
-import { type GainMapMetadata } from '../core/types'
+import { type GainMapMetadata, type QuadRendererTextureOptions } from '../core/types'
 
 /**
  * Necessary parameters for decoding a Gainmap
@@ -36,6 +36,10 @@ export type DecodeParameters = {
   /**
    * WebGLRenderer used to decode the GainMap
    */
-  renderer?: WebGLRenderer
+  renderer?: WebGLRenderer,
+  /**
+   * Options to use when creating the output renderTarget
+   */
+  renderTargetOptions?: QuadRendererTextureOptions
 
 } & GainmapDecodingParameters & GainMapMetadata

--- a/src/encode/encode.ts
+++ b/src/encode/encode.ts
@@ -62,7 +62,7 @@ export const encode = (params: EncodingParametersBase) => {
 
   const dataTexture = getDataTexture(image)
 
-  const sdr = getSDRRendition(dataTexture, renderer, params.toneMapping)
+  const sdr = getSDRRendition(dataTexture, renderer, params.toneMapping, params.renderTargetOptions)
 
   const gainMapRenderer = getGainMap({
     ...params,

--- a/src/encode/find-texture-min-max.ts
+++ b/src/encode/find-texture-min-max.ts
@@ -91,14 +91,14 @@ export const findTextureMinMax = (image: EXR | RGBE | LogLuv | DataTexture, mode
   let w = srcTex.image.width
   let h = srcTex.image.height
 
-  const quadRenderer = new QuadRenderer(
-    w,
-    h,
-    srcTex.type,
-    srcTex.colorSpace,
-    mat,
+  const quadRenderer = new QuadRenderer({
+    width: w,
+    height: h,
+    type: srcTex.type,
+    colorSpace: srcTex.colorSpace,
+    material: mat,
     renderer
-  )
+  })
 
   const frameBuffers: WebGLRenderTarget[] = []
 

--- a/src/encode/get-gainmap.ts
+++ b/src/encode/get-gainmap.ts
@@ -25,14 +25,15 @@ export const getGainMap = (params: { sdr: InstanceType<typeof QuadRenderer> } & 
     hdr: dataTexture
   })
 
-  const quadRenderer = new QuadRenderer(
-    dataTexture.image.width,
-    dataTexture.image.height,
-    UnsignedByteType,
-    LinearSRGBColorSpace,
+  const quadRenderer = new QuadRenderer({
+    width: dataTexture.image.width,
+    height: dataTexture.image.height,
+    type: UnsignedByteType,
+    colorSpace: LinearSRGBColorSpace,
     material,
-    renderer
-  )
+    renderer,
+    renderTargetOptions: params.renderTargetOptions
+  })
   try {
     quadRenderer.render()
   } catch (e) {

--- a/src/encode/get-sdr-rendition.ts
+++ b/src/encode/get-sdr-rendition.ts
@@ -7,6 +7,7 @@ import {
 } from 'three'
 
 import { QuadRenderer } from '../core/QuadRenderer'
+import { QuadRendererTextureOptions } from '../decode'
 import { SDRMaterial } from './materials/SDRMaterial'
 
 /**
@@ -18,18 +19,20 @@ import { SDRMaterial } from './materials/SDRMaterial'
  * @param hdrTexture The HDR image to be rendered
  * @param renderer (optional) WebGLRenderer to use during the rendering, a disposable renderer will be create and destroyed if this is not provided.
  * @param toneMapping (optional) Tone mapping to be applied to the SDR Rendition
+ * @param renderTargetOptions (optional) Options to use when creating the output renderTarget
  * @throws {Error} if the WebGLRenderer fails to render the SDR image
  */
-export const getSDRRendition = (hdrTexture: DataTexture, renderer?: WebGLRenderer, toneMapping?: ToneMapping): InstanceType<typeof QuadRenderer<typeof UnsignedByteType, InstanceType<typeof SDRMaterial>>> => {
+export const getSDRRendition = (hdrTexture: DataTexture, renderer?: WebGLRenderer, toneMapping?: ToneMapping, renderTargetOptions?: QuadRendererTextureOptions): InstanceType<typeof QuadRenderer<typeof UnsignedByteType, InstanceType<typeof SDRMaterial>>> => {
   hdrTexture.needsUpdate = true
-  const quadRenderer = new QuadRenderer(
-    hdrTexture.image.width,
-    hdrTexture.image.height,
-    UnsignedByteType,
-    SRGBColorSpace,
-    new SDRMaterial({ map: hdrTexture, toneMapping }),
-    renderer
-  )
+  const quadRenderer = new QuadRenderer({
+    width: hdrTexture.image.width,
+    height: hdrTexture.image.height,
+    type: UnsignedByteType,
+    colorSpace: SRGBColorSpace,
+    material: new SDRMaterial({ map: hdrTexture, toneMapping }),
+    renderer,
+    renderTargetOptions
+  })
   try {
     quadRenderer.render()
   } catch (e) {

--- a/src/encode/types.ts
+++ b/src/encode/types.ts
@@ -3,6 +3,7 @@ import { type EXR } from 'three/examples/jsm/loaders/EXRLoader'
 import { type LogLuv } from 'three/examples/jsm/loaders/LogLuvLoader'
 import { type RGBE } from 'three/examples/jsm/loaders/RGBELoader'
 
+import { QuadRendererTextureOptions } from '../decode'
 import { WorkerInterfaceImplementation } from '../worker-types'
 
 /**
@@ -85,6 +86,10 @@ export type EncodingParametersBase = GainmapEncodingParameters & {
    * @defaultValue `ACESFilmicToneMapping`
    */
   toneMapping?: ToneMapping
+  /**
+   * Options to use when creating the output renderTarget
+   */
+  renderTargetOptions?: QuadRendererTextureOptions
 }
 
 /**


### PR DESCRIPTION
related issue: #14 

The library will no more generate mipmaps by default but will require to explicitly enable them, also, in general, the library will assume a more 'un-opinionated' stance regarding the output texture options.

BREAKING CHANGE: `generateMipmaps` is no longer `true` by default, both `minFilter` is  no longer `LinearMipMapLinearFilter` by default but `LinearFilter`, `wrapS` and `warpT` are no longer `RepeatWrapping` by default but `ClampToEdgeWrapping`