### PR TITLE
fix(loaders): properly catches render errors and call `onError` callback

### DIFF
--- a/src/decode/loaders/GainMapLoader.ts
+++ b/src/decode/loaders/GainMapLoader.ts
@@ -79,7 +79,17 @@ export class GainMapLoader extends LoaderBase<[string, string, string]> {
 
     const loadCheck = async () => {
       if (sdr && gainMap && metadata) {
-        await this.render(quadRenderer, metadata, sdr, gainMap)
+        // solves #16
+        try {
+          await this.render(quadRenderer, metadata, sdr, gainMap)
+        } catch (error) {
+          this.manager.itemError(sdrUrl)
+          this.manager.itemError(gainMapUrl)
+          this.manager.itemError(metadataUrl)
+          if (typeof onError === 'function') onError(error)
+          quadRenderer.disposeOnDemandRenderer()
+          return
+        }
 
         if (typeof onLoad === 'function') onLoad(quadRenderer)
         this.manager.itemEnd(sdrUrl)

--- a/src/decode/loaders/HDRJPGLoader.ts
+++ b/src/decode/loaders/HDRJPGLoader.ts
@@ -109,7 +109,16 @@ export class HDRJPGLoader extends LoaderBase<string> {
           throw e
         }
       }
-      await this.render(quadRenderer, metadata, sdrJPEG, gainMapJPEG)
+
+      // solves #16
+      try {
+        await this.render(quadRenderer, metadata, sdrJPEG, gainMapJPEG)
+      } catch (error) {
+        this.manager.itemError(url)
+        if (typeof onError === 'function') onError(error)
+        quadRenderer.disposeOnDemandRenderer()
+        return
+      }
 
       if (typeof onLoad === 'function') onLoad(quadRenderer)
       this.manager.itemEnd(url)


### PR DESCRIPTION
related issue: #16 

the problem is caused by the fact that an empty string or any other "real-file-but-not-an-image" (an empty string is a request to load index.html basically) gets fulfilled by the server with a 200 OK status, returned by FileLoader -> we get the HTML in return (which is not an image) and then we try to render it anyway.

this catches errors in the LoaderBase render function and properly calls the `onError` callback